### PR TITLE
Add jupytext

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -21,11 +21,15 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
 
-      - uses: actions/checkout@v3 
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10' 
+          python-version: '3.10'
       - run: pip install -r requirements.txt
+
+      - name: Generate downloadable scripts
+        run: |
+          cd docs/tutorials; jupytext --to py *[!index].md; cd -
 
       - name: Build website
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# Install the pre-commit hooks below with
+# 'pre-commit install'
+
+# Auto-update the version of the hooks with
+# 'pre-commit autoupdate'
+
+# Run the hooks on all files with
+# 'pre-commit run --all'
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We welcome contributions to the Acquire code base and to documentation. Refer to
 
 - [`Acquire` project](https://github.com/acquire-project)
 - [`acquire-imaging`](https://github.com/acquire-project/acquire-python)
-- [`Acquire` documentation](https://github.com/acquire-project/acquire-docs)  
+- [`Acquire` documentation](https://github.com/acquire-project/acquire-docs)
 
 ## Build
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -10,10 +10,10 @@ The `AvailableData` class represents the collection of frames that have been cap
 class AvailableData:
     def frames(self) -> Iterator[VideoFrame]:
         """Returns an iterator over the video frames in the available data."""
-    
+
     def get_frame_count(self) -> int:
         """Returns the total number of video frames in the available data."""
-    
+
     def __iter__(self) -> Iterator[VideoFrame]:
         """Returns an iterator over the video frames in the available data."""
 ```
@@ -22,7 +22,7 @@ class AvailableData:
 
 - Call `get_frame_count()` to query the number of frames in an `AvailableData` object.
 
-- The `__iter__` method enables `AvailableData` objects to be iterated. 
+- The `__iter__` method enables `AvailableData` objects to be iterated.
 
 ## Class `Camera`
 The `Camera` class is used to describe cameras or other video sources.
@@ -34,7 +34,7 @@ class Camera:
 
     def __init__(self, *args: None, **kwargs: Any) -> None: ...
     """Initializes a Camera object with optional arguments."""
-    
+
     def dict(self) -> Dict[str, Any]: ...
     """Returns a dictionary of the Camera attributes."""
 ```
@@ -62,7 +62,7 @@ class CameraProperties:
 
     def __init__(self, *args: None, **kwargs: Any) -> None: ...
     """Initializes a CameraProperties object with optional arguments."""
-    
+
     def dict(self) -> Dict[str, Any]: ...
     """Returns a dictionary of the CameraProperties attributes."""
 ```
@@ -127,19 +127,19 @@ class DeviceIdentifier:
 
     def __eq__(self, other: object) -> bool:
         """Checks if two DeviceIdentifier objects are equal."""
-        
+
     def __ge__(self, other: object) -> bool:
         """Checks if this DeviceIdentifier is greater than or equal to another."""
-        
+
     def __gt__(self, other: object) -> bool:
         """Checks if this DeviceIdentifier is greater than another."""
-        
+
     def __le__(self, other: object) -> bool:
         """Checks if this DeviceIdentifier is less than or equal to another."""
-        
+
     def __lt__(self, other: object) -> bool:
         """Checks if this DeviceIdentifier is less than another."""
-        
+
     def __ne__(self, other: object) -> bool:
         """Checks if two DeviceIdentifier objects are not equal."""
 ```
@@ -169,27 +169,27 @@ class DeviceKind:
 
     def __eq__(self, other: object) -> bool:
         """Checks if two DeviceKind objects are equal."""
-        
+
     def __ge__(self, other: object) -> bool:
         """Checks if this DeviceKind is greater than or equal to another."""
-        
+
     def __gt__(self, other: object) -> bool:
         """Checks if this DeviceKind is greater than another."""
-        
+
     def __int__(self) -> int:
         """Converts the DeviceKind to an integer."""
-        
+
     def __le__(self, other: object) -> bool:
         """Checks if this DeviceKind is less than or equal to another."""
-        
+
     def __lt__(self, other: object) -> bool:
         """Checks if this DeviceKind is less than another."""
-        
+
     def __ne__(self, other: object) -> bool:
         """Checks if two DeviceKind objects are not equal."""
 ```
 
-- `Camera`: Enum-type class variable of `DeviceKind` that specifies a device is a camera. 
+- `Camera`: Enum-type class variable of `DeviceKind` that specifies a device is a camera.
 
 - `NONE`: Enum-type class variable of `DeviceKind` for if a device's kind is unavailable.
 
@@ -199,7 +199,7 @@ class DeviceKind:
 
 - `Storage`: Enum-type class variable of `DeviceKind` that specifies a device is for storage.
 
-## Class `DeviceManager` 
+## Class `DeviceManager`
 
 The `DeviceManager` class manages selection of available devices in the system. Regular expressions are accepted for the name argument.
 
@@ -207,32 +207,32 @@ The `DeviceManager` class manages selection of available devices in the system. 
 class DeviceManager:
     def devices(self) -> List[DeviceIdentifier]:
         """Returns a list of all available device identifiers."""
-    
+
     @overload
     def select(self, kind: DeviceKind, name: Optional[str]) -> Optional[DeviceIdentifier]:
         """Selects a specified device.
-        
+
         Args:
             kind (DeviceKind): The type of device to select.
             name (Optional[str]): The name of the device to select. Regular expressions supported.
-            
+
         Returns:
             Optional[DeviceIdentifier]: The selected device identifier, or None if the specified device is not available.
         """
-    
+
     def select_one_of(self, kind: DeviceKind, names: List[str]) -> Optional[DeviceIdentifier]:
         """Selects the first device in the list of devices that is of one of the specified kinds.
-        
+
         Args:
             kind (DeviceKind): The type of device to select.
             names (List[str]): A list of device names to choose from. Regular expressions supported.
-            
+
         Returns:
             Optional[DeviceIdentifier]: The selected device identifier, or None if none of the specified devices are available.
         """
 ```
 
-- Call `devices` to list the `DeviceIdentifier` of each available device. 
+- Call `devices` to list the `DeviceIdentifier` of each available device.
 
 - Call `select` to choose the first available device of a given type or to select a specific device by name.
 
@@ -251,27 +251,27 @@ class DeviceState:
 
     def __eq__(self, other: object) -> bool:
         """Checks if two DeviceState objects are equal."""
-        
+
     def __ge__(self, other: object) -> bool:
         """Checks if this DeviceState is greater than or equal to another."""
-        
+
     def __gt__(self, other: object) -> bool:
         """Checks if this DeviceState is greater than another."""
-        
+
     def __int__(self) -> int:
         """Converts the DeviceState to an integer."""
-        
+
     def __le__(self, other: object) -> bool:
         """Checks if this DeviceState is less than or equal to another."""
-        
+
     def __lt__(self, other: object) -> bool:
         """Checks if this DeviceState is less than another."""
-        
+
     def __ne__(self, other: object) -> bool:
         """Checks if two DeviceState objects are not equal."""
 ```
 
-- `Closed`: Enum-type class variable of `DeviceState` that species when a device is not ready for configuration. 
+- `Closed`: Enum-type class variable of `DeviceState` that species when a device is not ready for configuration.
 
 - `AwaitingConfiguration`: Enum-type class variable of `DeviceState` that species when a device is ready for configuration.
 
@@ -290,27 +290,27 @@ class Direction:
 
     def __eq__(self, other: object) -> bool:
         """Checks if two Direction objects are equal."""
-        
+
     def __ge__(self, other: object) -> bool:
         """Checks if this Direction is greater than or equal to another."""
-        
+
     def __gt__(self, other: object) -> bool:
         """Checks if this Direction is greater than another."""
-        
+
     def __int__(self) -> int:
         """Converts the Direction to an integer."""
-        
+
     def __le__(self, other: object) -> bool:
         """Checks if this Direction is less than or equal to another."""
-        
+
     def __lt__(self, other: object) -> bool:
         """Checks if this Direction is less than another."""
-        
+
     def __ne__(self, other: object) -> bool:
         """Checks if two Direction objects are not equal."""
 ```
 
-- `Backward`: Enum-type class variable of `Direction` that species when data is streamed backward. 
+- `Backward`: Enum-type class variable of `Direction` that species when data is streamed backward.
 
 - `Forward`: Enum-type class variable of `Direction` that species when data is streamed forward.
 
@@ -402,7 +402,7 @@ class Properties:
 
 - The `dict` method creates a dictionary of a `Properties` object's attributes.
 
-## Class `Runtime` 
+## Class `Runtime`
 
 The `Runtime` class coordinates the devices with the storage disc including selecting the devices, setting their properties, and starting and stopping acqusition.
 
@@ -410,47 +410,47 @@ The `Runtime` class coordinates the devices with the storage disc including sele
 class Runtime:
     def __init__(self, *args: None, **kwargs: Any) -> None:
         """Initializes the Runtime object with optional arguments."""
-    
+
     def device_manager(self) -> DeviceManager:
         """Returns the DeviceManager instance associated with this Runtime."""
-    
+
     def get_available_data(self, stream_id: int) -> AvailableData:
         """Returns the AvailableData instance for the given stream ID.
-        
+
         Args:
             stream_id (int): The ID of the stream for which available data is requested.
-            
+
         Returns:
             AvailableData: The AvailableData instance for the given VideoStream ID.
         """
-    
+
     def get_configuration(self) -> Properties:
         """Returns the current configuration properties of the runtime."""
-    
+
     def get_state(self) -> DeviceState:
         """Returns the current state of the device."""
-    
+
     def set_configuration(self, properties: Properties) -> Properties:
         """Applies the provided configuration properties to the runtime.
-        
+
         Args:
             properties (Properties): The properties to be set.
-            
+
         Returns:
             Properties: The updated configuration properties.
         """
-    
+
     def start(self) -> None:
         """Starts the runtime, allowing it to collect data."""
-    
+
     def stop(self) -> None:
         """Stops the runtime, ending data collection after the max number of frames is collected."""
-    
+
     def abort(self) -> None:
         """Aborts the runtime, terminating it immediately."""
 ```
 
-- Call `device_manager()` to return the `DeviceManager` object associated with this `Runtime` instance. 
+- Call `device_manager()` to return the `DeviceManager` object associated with this `Runtime` instance.
 
 - Call `get_available_data` with a specific `stream_id`, 0 or 1, to return the `AvailableData` associated with the 1st or 2nd video source, respectively.
 
@@ -505,22 +505,22 @@ class SampleType:
 
     def __eq__(self, other: object) -> bool:
         """Checks if two SampleType objects are equal."""
-        
+
     def __ge__(self, other: object) -> bool:
         """Checks if this SampleType is greater than or equal to another."""
-        
+
     def __gt__(self, other: object) -> bool:
         """Checks if this SampleType is greater than another."""
-        
+
     def __int__(self) -> int:
         """Converts the SampleType to an integer."""
-        
+
     def __le__(self, other: object) -> bool:
         """Checks if this SampleType is less than or equal to another."""
-        
+
     def __lt__(self, other: object) -> bool:
         """Checks if this SampleType is less than another."""
-        
+
     def __ne__(self, other: object) -> bool:
         """Checks if two SampleType objects are not equal."""
 ```
@@ -552,22 +552,22 @@ class SignalIOKind:
 
     def __eq__(self, other: object) -> bool:
         """Checks if two SignalIOKind objects are equal."""
-        
+
     def __ge__(self, other: object) -> bool:
         """Checks if this SignalIOKind is greater than or equal to another."""
-        
+
     def __gt__(self, other: object) -> bool:
         """Checks if this SignalIOKind is greater than another."""
-        
+
     def __int__(self) -> int:
         """Converts the SignalIOKind to an integer."""
-        
+
     def __le__(self, other: object) -> bool:
         """Checks if this SignalIOKind is less than or equal to another."""
-        
+
     def __lt__(self, other: object) -> bool:
         """Checks if this SignalIOKind is less than another."""
-        
+
     def __ne__(self, other: object) -> bool:
         """Checks if two SignalIOKind objects are not equal."""
 ```
@@ -587,22 +587,22 @@ class SignalType:
 
     def __eq__(self, other: object) -> bool:
         """Checks if two SignalType objects are equal."""
-        
+
     def __ge__(self, other: object) -> bool:
         """Checks if this SignalType is greater than or equal to another."""
-        
+
     def __gt__(self, other: object) -> bool:
         """Checks if this SignalType is greater than another."""
-        
+
     def __int__(self) -> int:
         """Converts the SignalType to an integer."""
-        
+
    def __le__(self, other: object) -> bool:
         """Checks if this SignalType is less than or equal to another."""
-        
+
     def __lt__(self, other: object) -> bool:
         """Checks if this SignalType is less than another."""
-        
+
     def __ne__(self, other: object) -> bool:
         """Checks if two SignalType objects are not equal."""
 ```
@@ -723,33 +723,33 @@ class TriggerEdge:
 
     def __eq__(self, other: object) -> bool:
         """Checks if two TriggerEdge objects are equal."""
-        
+
     def __ge__(self, other: object) -> bool:
         """Checks if this TriggerEdge is greater than or equal to another."""
-        
+
     def __gt__(self, other: object) -> bool:
         """Checks if this TriggerEdge is greater than another."""
-        
+
     def __int__(self) -> int:
         """Converts the TriggerEdge to an integer."""
-        
+
     def __le__(self, other: object) -> bool:
         """Checks if this TriggerEdge is less than or equal to another."""
-        
+
     def __lt__(self, other: object) -> bool:
         """Checks if this TriggerEdge is less than another."""
-        
+
     def __ne__(self, other: object) -> bool:
         """Checks if two TriggerEdge objects are not equal."""
 ```
 
-- `Falling`: Enum-type class variable of `TriggerEdge` that defines the falling edge of the trigger. 
+- `Falling`: Enum-type class variable of `TriggerEdge` that defines the falling edge of the trigger.
 
 - `NotApplicable`: Enum-type class variable of `TriggerEdge` that defines if a trigger does not have a rising or falling edge.
 
 - `Rising`: Enum-type class variable of `TriggerEdge` that defines the rising edge of the trigger.
 
-## Class `VideoFrame` 
+## Class `VideoFrame`
 
 The `VideoFrame` class represents data from acquisition of a frame.
 
@@ -757,14 +757,14 @@ The `VideoFrame` class represents data from acquisition of a frame.
 class VideoFrame:
     def data(self) -> NDArray[Any]:
         """Returns the data of the video frame as an NDArray."""
-    
+
     def metadata(self) -> VideoFrameMetadata:
         """Returns the metadata associated with the video frame."""
 ```
 
-- Call `data()` to create an NDArray of the `VideoFrame` data. 
+- Call `data()` to create an NDArray of the `VideoFrame` data.
 
-- Call `metadata()` to create a `VideoFrameMetadata` object containing the metadata of `VideoFrame`. 
+- Call `metadata()` to create a `VideoFrameMetadata` object containing the metadata of `VideoFrame`.
 
 ## Class `VideoFrameMetadata`
 

--- a/docs/examples/livestream_napari.py
+++ b/docs/examples/livestream_napari.py
@@ -9,7 +9,7 @@ runtime = acquire.Runtime()
 dm = runtime.device_manager()
 
 # Grab the current configuration
-config = runtime.get_configuration() 
+config = runtime.get_configuration()
 
 # Select the uniform random camera as the video source
 config.video[0].camera.identifier = dm.select(acquire.DeviceKind.Camera, ".*random.*")
@@ -25,8 +25,8 @@ config.video[0].camera.settings.shape = (300, 200)
 # Set the max frame count to 100 frames
 config.video[0].max_frame_count = 100
 
-# Update the configuration with the chosen parameters 
-config = runtime.set_configuration(config) 
+# Update the configuration with the chosen parameters
+config = runtime.set_configuration(config)
 
 # import napari and open a viewer to stream the data
 import napari
@@ -73,7 +73,7 @@ def do_acquisition():
 
     stream = 1
     # loop to continue to update the data in napari while acquisition is running
-    while is_not_done():  
+    while is_not_done():
         if (frame := next_frame()) is not None:
             yield frame, stream_id
         time.sleep(0.1)

--- a/docs/for_contributors/index.md
+++ b/docs/for_contributors/index.md
@@ -1,10 +1,7 @@
 # For contributors
 
-Thank you for your interest in contributing to `Acquire`! We welcome contributions to the code base and to documentation. 
+Thank you for your interest in contributing to `Acquire`! We welcome contributions to the code base and to documentation.
 
 - [`Acquire` project](https://github.com/acquire-project)
 - [`acquire-imaging`](https://github.com/acquire-project/acquire-python)
-- [`Acquire` documentation](https://github.com/acquire-project/acquire-docs)  
-
-
-
+- [`Acquire` documentation](https://github.com/acquire-project/acquire-docs)

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -2,7 +2,7 @@
 
 Acquire (`acquire-imaging` [on PyPI](https://pypi.org/project/acquire-imaging/)) is a Python package providing a multi-camera video streaming library focused on performant microscopy, with support for up to two simultaneous, independent, video streams.
 
-This tutorial covers Acquire installation and shows an example of using Acquire with its provided simulated cameras to demonstrate the acquisition process. 
+This tutorial covers Acquire installation and shows an example of using Acquire with its provided simulated cameras to demonstrate the acquisition process.
 
 ## Installation
 

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -253,3 +253,11 @@ li.md-source__fact {
 .md-header__ellipsis a:hover {
     color: white;
 }
+
+a.md-button-center {
+    display: flex !important;
+    justify-content: center;
+    max-width: fit-content;
+    margin-left: auto;
+    margin-right: auto;
+}

--- a/docs/tutorials/chunked.md
+++ b/docs/tutorials/chunked.md
@@ -17,10 +17,10 @@ runtime = acquire.Runtime()
 dm = runtime.device_manager()
 
 # Grab the current configuration
-config = runtime.get_configuration() 
+config = runtime.get_configuration()
 
 # Select the radial sine simulated camera as the video source
-config.video[0].camera.identifier = dm.select(acquire.DeviceKind.Camera, "simulated: radial sin") 
+config.video[0].camera.identifier = dm.select(acquire.DeviceKind.Camera, "simulated: radial sin")
 
 # Set the storage to Zarr to take advantage of chunking
 config.video[0].storage.identifier = dm.select(acquire.DeviceKind.Storage, "Zarr")
@@ -43,7 +43,7 @@ config.video[0].storage.settings.filename = "out.zarr"
 Below we'll configure the chunking specific settings and update all settings with the `set_configuration` method.
 
 ```python
-# Chunk size may need to be optimized for each acquisition. 
+# Chunk size may need to be optimized for each acquisition.
 # See Zarr documentation for further guidance:
 # https://zarr.readthedocs.io/en/stable/tutorial.html#chunk-optimizations
 config.video[0].storage.settings.chunking.max_bytes_per_chunk = 32 * 2**20 # 32 MB
@@ -86,3 +86,5 @@ The output will be:
 <zarr.core.Array '/0' (10, 1, 1080, 1920) uint8>
 ```
 As expected, we have only 1 top level directory, corresponding to the single array in the group. We would expect more than 1 array only if we were writing [multiscale data](multiscale.md). The overall array shape is (10, 1, 1080, 1920), corresponding to 10 frames, 1 channel, and a height and width of 1080 and 1920, respectively, per frame.
+
+[Download this tutorial as a Python script](chunked.py){ .md-button .md-button-center }

--- a/docs/tutorials/compressed.md
+++ b/docs/tutorials/compressed.md
@@ -19,10 +19,10 @@ runtime = acquire.Runtime()
 dm = runtime.device_manager()
 
 # Grab the current configuration
-config = runtime.get_configuration() 
+config = runtime.get_configuration()
 
 # Select the radial sine simulated camera as the video source
-config.video[0].camera.identifier = dm.select(acquire.DeviceKind.Camera, "simulated: radial sin") 
+config.video[0].camera.identifier = dm.select(acquire.DeviceKind.Camera, "simulated: radial sin")
 
 # Set the storage to ZarrBlosc1ZstdByteShuffle to avoid saving the data
 config.video[0].storage.identifier = dm.select(acquire.DeviceKind.Storage, "ZarrBlosc1ZstdByteShuffle")
@@ -38,9 +38,10 @@ config.video[0].max_frame_count = 100 # collect 100 frames
 # Set the output file to out.zarr
 config.video[0].storage.settings.filename = "out.zarr"
 
-# Update the configuration with the chosen parameters 
-config = runtime.set_configuration(config) 
+# Update the configuration with the chosen parameters
+config = runtime.set_configuration(config)
 ```
+
 ## Inspect Acquired Data
 
 Now that the configuration is set to utilize the `ZarrBlosc1ZstdByteShuffle` storage device, we can acquire data, which will be compressed before it is stored to `out.zarr`. Since we did not specify the size of chunks, the data will be saved as a single chunk that is the size of the image data. You may specify chunk sizes using the `TileShape` class. For example, using `acquire.StorageProperties.chunking.tile.width` to set the width of the chunks.
@@ -50,7 +51,9 @@ Now that the configuration is set to utilize the `ZarrBlosc1ZstdByteShuffle` sto
 runtime.start()
 runtime.stop()
 ```
-We'll use the [Zarr Python package](https://zarr.readthedocs.io/en/stable/) to read the data in `out.zarr` file. 
+
+We'll use the [Zarr Python package](https://zarr.readthedocs.io/en/stable/) to read the data in `out.zarr` file.
+
 ```python
 # We'll utilize the Zarr python package to read the data
 import zarr
@@ -72,9 +75,13 @@ print(data.compressor.shuffle)
 ```
 
 Output:
+
 ```
 zstd
 1
 1
 ```
+
 As expected, the data was compressed using the `zstd` codec.
+
+[Download this tutorial as a Python script](compressed.py){ .md-button .md-button-center }

--- a/docs/tutorials/configure.md
+++ b/docs/tutorials/configure.md
@@ -27,7 +27,7 @@ config = runtime.get_configuration()
 
 ```python
 # Select the radial sine simulated camera as the video source
-config.video[0].camera.identifier = dm.select(acquire.DeviceKind.Camera, "simulated: radial sin") 
+config.video[0].camera.identifier = dm.select(acquire.DeviceKind.Camera, "simulated: radial sin")
 
 # Set the storage to Tiff
 config.video[0].storage.identifier = dm.select(acquire.DeviceKind.Storage, "Tiff")
@@ -45,7 +45,7 @@ config.video[0].max_frame_count = 100
 ```
 
 ## Configure `Camera`
-`Camera` class objects have 2 attributes, `settings`, a `CameraProperties` object, and an optional attribute `identifier`, which is a `DeviceIdentifier` object. 
+`Camera` class objects have 2 attributes, `settings`, a `CameraProperties` object, and an optional attribute `identifier`, which is a `DeviceIdentifier` object.
 
 `CameraProperties` has 5 attributes that are numbers and specify the exposure time and line interval in microseconds, how many pixels, if any, to bin (set to 1 by default to disable), and tuples for the image size and location on the camera chip. The other attributes are all instances of different classes. The `pixel_type` attribute is a `SampleType` object which indicates the data type of the pixel values in the image, such as Uint8. The `readout_direction` attribute is a `Direction` object specifying whether the data is read forwards or backwards from the camera. The `input_triggers` attribute is an `InputTriggers` object that details the characteristics of any input triggers in the system. The `output_triggers` attribute is an `OutputTriggers` object that details the characteristics of any output triggers in the system. All of the attributes of `InputTriggers` and `OutputTriggers` objects are instances of the `Trigger` class. The `Trigger` class is described in [this tutorial](https://acquire-project.github.io/acquire-docs/tutorials/trig_json/).
 
@@ -63,7 +63,7 @@ config.video[0].camera.settings.pixel_type = acquire.SampleType.U32
 ```
 
 ## Configure `Storage`
-`Storage` objects have 2 attributes, `settings`, a `StorageProperties` object, and an optional attribute `identifier`, which is an instance of the `DeviceIdentifier` class described above. 
+`Storage` objects have 2 attributes, `settings`, a `StorageProperties` object, and an optional attribute `identifier`, which is an instance of the `DeviceIdentifier` class described above.
 
 `StorageProperties` has 2 attributes `external_metadata_json` and `filename` which are strings of the filename or filetree of the output metadata in JSON format and image data in whatever format corresponds to the selected storage device, respectively. `first_frame_id` is an integer ID that corresponds to the first frame of the current acquisition and is typically 0. `pixel_scale_um` is the camera pixel size in microns. `enable_multiscale` is a boolean used to specify if the data should be saved as an image pyramid. See the [multiscale tutorial](multiscale.md) for more information. The `chunking` attribute is an instance of the `ChunkingProperties` class, used for Zarr storage. See the [chunking tutorial](multiscale.md) for more information.
 
@@ -75,9 +75,11 @@ config.video[0].storage.settings.filename = "out.tiff"
 ```
 
 # Update Configuration Settings
-None of the configuration settings are updated in `Runtime` until the `set_configuration` method is called. We'll be creating a new `Properties` object with the `set_configuration` method. For simplicity, we'll reuse `config` for the name of that object as well, but note that `new_config = runtime.set_configuration(config)` also works here. 
+None of the configuration settings are updated in `Runtime` until the `set_configuration` method is called. We'll be creating a new `Properties` object with the `set_configuration` method. For simplicity, we'll reuse `config` for the name of that object as well, but note that `new_config = runtime.set_configuration(config)` also works here.
 
 ```python
-# Update the configuration with the chosen parameters 
-config = runtime.set_configuration(config) 
+# Update the configuration with the chosen parameters
+config = runtime.set_configuration(config)
 ```
+
+[Download this tutorial as a Python script](configure.py){ .md-button .md-button-center }

--- a/docs/tutorials/drivers.md
+++ b/docs/tutorials/drivers.md
@@ -18,7 +18,7 @@ Acquire provides the following simulated cameras:
 Acquire will only identify cameras whose drivers are present on your machine. The `DeviceManager` class manages selection of cameras and storage. We can create a `DeviceManager` object using the following:
 
 ```python
-import acquire 
+import acquire
 
 # Instantiate a Runtime object
 runtime = acquire.Runtime()
@@ -33,6 +33,7 @@ dm = runtime.device_manager()
 for device in dm.devices():
     print(device)
 ```
+
 The output of this code is below. All discovered devices, both cameras and storage devices, will be listed. In this tutorial, no cameras were connected to the machine, so only simulated cameras were found. Note that the storage devices also printed.
 
 ```
@@ -54,3 +55,4 @@ For cameras that weren't discovered you will see an error like the one below. Th
 ERROR acquire.runtime 2023-10-20 19:03:17,917 runtime.rs:40 C:\actions-runner\_work\acquire-driver-hdcam\acquire-driver-hdcam\src\acquire-core-libs\src\acquire-device-hal\device\hal\loader.c:114 - driver_load(): Failed to load driver at "acquire-driver-hdcam".
 ```
 
+[Download this tutorial as a Python script](drivers.py){ .md-button .md-button-center }

--- a/docs/tutorials/framedata.md
+++ b/docs/tutorials/framedata.md
@@ -1,6 +1,6 @@
 # Accessing Data during Acquisition
 
-This tutorial will provide an example of accessing data from a video source during acquisition. 
+This tutorial will provide an example of accessing data from a video source during acquisition.
 
 ## Configure `Runtime`
 
@@ -16,10 +16,10 @@ runtime = acquire.Runtime()
 dm = runtime.device_manager()
 
 # Grab the current configuration
-config = runtime.get_configuration() 
+config = runtime.get_configuration()
 
 # Select the radial sine simulated camera as the video source
-config.video[0].camera.identifier = dm.select(acquire.DeviceKind.Camera, "simulated: radial sin") 
+config.video[0].camera.identifier = dm.select(acquire.DeviceKind.Camera, "simulated: radial sin")
 
 # Set the storage to trash to avoid saving the data
 config.video[0].storage.identifier = dm.select(acquire.DeviceKind.Storage, "Trash")
@@ -32,8 +32,8 @@ config.video[0].camera.settings.shape = (1024, 768)
 # Set the max frame count to 2**(64-1) the largest number supported by Uint64 for essentially infinite acquisition
 config.video[0].max_frame_count = 100 # collect 100 frames
 
-# Update the configuration with the chosen parameters 
-config = runtime.set_configuration(config) 
+# Update the configuration with the chosen parameters
+config = runtime.set_configuration(config)
 ```
 ## Working with `AvailableData` objects
 
@@ -52,7 +52,7 @@ time.sleep(0.5)
 
 # grab the packet of data available on disk for video stream 0.
 # This is an AvailableData object.
-available_data = runtime.get_available_data(0) 
+available_data = runtime.get_available_data(0)
 ```
 
 There may not be data available, in which case our variable `available_data` would be `None`. To avoid errors associated with this circumstance, we'll only grab data if `available_data` is not `None`.
@@ -65,12 +65,12 @@ Once `get_available_data()` is called the `AvailableData` object will be locked 
 # We can only grab frames if data is available.
 if available_data is not None:
 
-       
+
     # frames is an iterator over available_data
     # we'll use this iterator to make a list of the frames
     video_frames = list(available_data.frames())
 
-else:         
+else:
     # delete the available_data variable
     # if there is no data in the packet to free up RAM
     del available_data
@@ -87,7 +87,7 @@ print(first_frame.shape)
 ```
 Output:
 ```
-(1, 768, 1024, 1) 
+(1, 768, 1024, 1)
 ```
 
 We can use the `numpy.squeeze` method to grab the desired NDArray image data from `first_frame` since the other dimensions are 1. This is equivalent to `image = first_frame[0][:, :, 0]`.
@@ -101,14 +101,16 @@ print(image.shape)
 Output:
 ```
 (768, 1024)
-``` 
-Finally, delete the `available_data` to unlock the region in the circular buffer. 
+```
+Finally, delete the `available_data` to unlock the region in the circular buffer.
 
 
-```python  
+```python
 # delete the available_data to free up disk space
 del available_data
 
 # stop runtime
 runtime.stop()
 ```
+
+[Download this tutorial as a Python script](framedata.py){ .md-button .md-button-center }

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -5,4 +5,3 @@ examples of using the API. Please submit an [issue on Github](https://github.com
 request a tutorial, or if you are also interested in contributing to a tutorial
 to this documentation please visit our
 [contribution guide](../for_contributors/index.md).
-

--- a/docs/tutorials/livestream.md
+++ b/docs/tutorials/livestream.md
@@ -5,3 +5,5 @@ The below script can be used to livestream data to the [napari viewer](https://n
 ~~~python
 {% include "../examples/livestream_napari.py" %}
 ~~~
+
+[Download this tutorial as a Python script](livestream.py){ .md-button .md-button-center }

--- a/docs/tutorials/multiscale.md
+++ b/docs/tutorials/multiscale.md
@@ -17,10 +17,10 @@ runtime = acquire.Runtime()
 dm = runtime.device_manager()
 
 # Grab the current configuration
-config = runtime.get_configuration() 
+config = runtime.get_configuration()
 
 # Select the radial sine simulated camera as the video source
-config.video[0].camera.identifier = dm.select(acquire.DeviceKind.Camera, "simulated: radial sin") 
+config.video[0].camera.identifier = dm.select(acquire.DeviceKind.Camera, "simulated: radial sin")
 
 # Set the storage to Zarr to have the option to save multiscale data
 config.video[0].storage.identifier = dm.select(acquire.DeviceKind.Storage, "Zarr")
@@ -47,7 +47,7 @@ config.video[0].storage.settings.filename = "out.zarr"
 To complete configuration, we'll configure the multiscale specific settings and update all settings with the `set_configuration` method.
 
 ```python
-# Chunk size may need to be optimized for each acquisition. 
+# Chunk size may need to be optimized for each acquisition.
 # See Zarr documentation for further guidance:
 # https://zarr.readthedocs.io/en/stable/tutorial.html#chunk-optimizations
 config.video[0].storage.settings.chunking.max_bytes_per_chunk = 16 * 2**20 # 16 MB
@@ -60,10 +60,11 @@ config.video[0].storage.settings.chunking.tile.height = (config.video[0].camera.
 # turn on multiscale mode
 config.video[0].storage.settings.enable_multiscale = True
 
-# Update the configuration with the chosen parameters 
-config = runtime.set_configuration(config) 
+# Update the configuration with the chosen parameters
+config = runtime.set_configuration(config)
 ```
 ## Collect and Inspect the Data
+
 ```python
 
 # collect data
@@ -85,12 +86,17 @@ With multiscale mode enabled, an image pyramid will be formed by rescaling the d
 ```python
 group["0"], group["1"], group["2"]
 ```
+
 The output will be:
+
 ```
 (<zarr.core.Array '/0' (10, 1, 1080, 1920) uint8>,
  <zarr.core.Array '/1' (5, 1, 540, 960) uint8>,
  <zarr.core.Array '/2' (2, 1, 270, 480) uint8>)
 ```
+
 Here, the `"0"` directory contains the full-resolution array of frames of size 1920 x 1080, with a single channel, saving all 10 frames.
 The `"1"` directory contains the first rescaled array of frames of size 960 x 540, averaging every two frames, taking the frame count from 10 to 5.
 The `"2"` directory contains a further rescaled array of frames of size 480 x 270, averaging every four frames, taking the frame count from 10 to 2. Notice that both the frame width and frame height are now smaller than the chunk width and chunk height of 640 and 360, respectively, so this should be the last array in the group.
+
+[Download this tutorial as a Python script](multiscale.py){ .md-button .md-button-center }

--- a/docs/tutorials/props_json.md
+++ b/docs/tutorials/props_json.md
@@ -13,12 +13,13 @@ runtime = acquire.Runtime()
 
 ## Configure Camera
 
-All camera settings are captured by an instance of the `Properties` class, which will be associated with a given camera acquisition. 
+All camera settings are captured by an instance of the `Properties` class, which will be associated with a given camera acquisition.
 
 ```python
 # Instantiate a Properties object for the Runtime
 config = runtime.get_configuration()
 ```
+
 You can update any of the settings in this instance of `Properties`. To save any updated settings, use the `set_configuration` method.  For this tutorial, we'll simply specify a camera, and then save these new settings. Note that more settings must be provided before this `Properties` object could be used for an acquistion. Check out [this tutorial](configure.md) for more information on configuring an acquisition.
 
 ```python
@@ -70,3 +71,4 @@ config = acquire.Properties(**json.load(open('sample_props.json')))
 config = runtime.set_configuration(config)
 ```
 
+[Download this tutorial as a Python script](props_json.py){ .md-button .md-button-center }

--- a/docs/tutorials/select.md
+++ b/docs/tutorials/select.md
@@ -5,7 +5,7 @@ This tutorial illustrates the difference between the `select` and `select_one_of
 To start, instantiate `Runtime` and `DeviceManager` objects and subsequently print the discovered devices.
 
 ```python
-import acquire 
+import acquire
 
 # Instantiate a Runtime object
 runtime = acquire.Runtime()
@@ -73,3 +73,5 @@ The output of the code is below. The Hamamatsu camera was not discovered by `Run
 ```
 <DeviceIdentifier Camera "simulated: radial sin">
 ```
+
+[Download this tutorial as a Python script](select.py){ .md-button .md-button-center }

--- a/docs/tutorials/setup.md
+++ b/docs/tutorials/setup.md
@@ -13,7 +13,7 @@ def setup(
 ) -> Properties
 ```
 
-The `setup` function can be used as a shorthand to simplify the `Runtime` configuration process. `setup` takes a `Runtime` object and strings of the camera and storage device names and returns a `Properties` object. You may also optionally specify the filename for writing the data. 
+The `setup` function can be used as a shorthand to simplify the `Runtime` configuration process. `setup` takes a `Runtime` object and strings of the camera and storage device names and returns a `Properties` object. You may also optionally specify the filename for writing the data.
 
 ## Example
 
@@ -26,7 +26,7 @@ runtime = acquire.Runtime()
 # use setup to get configuration and set the camera, storage, and filename
 config = acquire.setup(runtime, "simulated: radial sin", "Zarr", "out.zarr")
 ```
-You can subsequently use `config` to specify additional settings and set those configurations before beginning acquisition. 
+You can subsequently use `config` to specify additional settings and set those configurations before beginning acquisition.
 
 Without using setup, the process would take a few additional lines of codes. The below code is equivalent to the example above.
 
@@ -37,10 +37,10 @@ import acquire
 runtime = acquire.Runtime()
 
 # Grab the current configuration
-config = runtime.get_configuration() 
+config = runtime.get_configuration()
 
 # Select the radial sine simulated camera as the video source
-config.video[0].camera.identifier = runtime.device_manager().select(acquire.DeviceKind.Camera, "simulated: radial sin") 
+config.video[0].camera.identifier = runtime.device_manager().select(acquire.DeviceKind.Camera, "simulated: radial sin")
 
 # Set the storage to Zarr to have the option to save multiscale data
 config.video[0].storage.identifier = runtime.device_manager().select(acquire.DeviceKind.Storage, "Zarr")
@@ -54,3 +54,5 @@ In either case, we can update the configuration settings using:
 ```python
 config = runtime.set_configuration(config)
 ```
+
+[Download this tutorial as a Python script](setup.py){ .md-button .md-button-center }

--- a/docs/tutorials/start_stop.md
+++ b/docs/tutorials/start_stop.md
@@ -1,6 +1,6 @@
 # Multiple Acquisitions
 
-This tutorial will provide an example of starting, stopping, and restarting acquisition, or streaming from a video source. 
+This tutorial will provide an example of starting, stopping, and restarting acquisition, or streaming from a video source.
 
 ## Configure Streaming
 
@@ -16,14 +16,14 @@ runtime = acquire.Runtime()
 # Choose Video Source and Storage Device
 config = acquire.setup(runtime, "simulated: radial sin", "Tiff")
 
-# Specify settings    
+# Specify settings
 config.video[0].storage.settings.filename == "out.tif"
 config.video[0].camera.settings.shape = (192, 108)
 config.video[0].camera.settings.exposure_time_us = 10e4
 config.video[0].max_frame_count = 10
 
-# Update the configuration with the chosen parameters 
-config = runtime.set_configuration(config) 
+# Update the configuration with the chosen parameters
+config = runtime.set_configuration(config)
 ```
 
 ## Start, Stop, and Restart Acquisition
@@ -32,7 +32,7 @@ During Acquisition, the `AvailableData` object is the streaming interface. Upon 
 
 To understand how acquisition works, we'll start, stop, and repeat acquisition and print the `DeviceState`, which can be `Armed`, `AwaitingConfiguration`, `Closed`, or `Running`, as well as print the `AvailableData` object throughout the process.
 
-If acquisition has ended, all of the objects are deleted, including `AvailableData` objects, so those will be `None` when not acquiring data. In addition, if enough time hasn't elapsed since acquisition started, `AvailableData` will also be `None`. We'll utilize the `time` python package to introduce time delays to account for these facts. 
+If acquisition has ended, all of the objects are deleted, including `AvailableData` objects, so those will be `None` when not acquiring data. In addition, if enough time hasn't elapsed since acquisition started, `AvailableData` will also be `None`. We'll utilize the `time` python package to introduce time delays to account for these facts.
 
 ```python
 # package used to introduce time delays
@@ -82,9 +82,11 @@ DeviceState.Armed
 <builtins.AvailableData object at 0x00000218D685E3D0>
 ```
 1. The first time we print is immediately after starting acquisition, so no time has elapsed for data collection as compared to the camera exposure time, so while the camera is running, `Running`, there is no data available.
-   
+
 3. The next print happens after waiting 0.5 seconds, so acquisition is still runnning and now there is acquired data available.
-   
+
 5. The subsequent print is following calling `runtime.stop()` which waits until the specified max number of frames is collected and then terminates acquisition. Thus, the device is no longer running and there is no available data, since all objects were deleted by calling the `stop` method. The device is in an `Armed` state ready for the next acquisition.
-   
+
 7. The final print occurs after waiting 5 seconds following the start of acquisition. This waiting period is longer than the 1 second acqusition time (0.1 seconds/frame and 10 frames), so the device is no longer collecting data. However, `runtime.stop()` hasn't been called, so the `AvailableData` object has not yet been deleted.
+
+[Download this tutorial as a Python script](start_stop.py){ .md-button .md-button-center }

--- a/docs/tutorials/storage.md
+++ b/docs/tutorials/storage.md
@@ -7,7 +7,7 @@ This tutorial describes the storage device options in `Acquire`.
 To start, we'll create a `Runtime` object and print the storage device options.
 
 ```python
-import acquire 
+import acquire
 
 # Instantiate a Runtime object
 runtime = acquire.Runtime()
@@ -32,22 +32,22 @@ The output of that script will be:
 <DeviceIdentifier Storage "ZarrBlosc1Lz4ByteShuffle">
 ```
 
-`Acquire` supports streaming data to [bigtiff](http://bigtiff.org/) and [Zarr V2](https://zarr.readthedocs.io/en/stable/spec/v2.html). 
+`Acquire` supports streaming data to [bigtiff](http://bigtiff.org/) and [Zarr V2](https://zarr.readthedocs.io/en/stable/spec/v2.html).
 
 Zarr has additional capabilities relative to the basic storage devices, namely _chunking_, _compression_, and _multiscale storage_. You can learn more about the Zarr capabilities in `Acquire` [here](https://github.com/acquire-project/acquire-driver-zarr).
 
 - **raw** - Streams to a raw binary file.
-  
+
 - **tiff** - Streams to a [bigtiff](http://bigtiff.org/) file. Metadata is stored in the `ImageDescription` tag for each frame as a `JSON` string.
-  
+
 - **trash** - Writes nothing. Discards incoming data. Useful for live streaming applications.
-  
+
 - **tiff-json** - Stores the video stream in a [bigtiff](http://bigtiff.org/), and stores metadata in a `JSON` file. Both are located in a folder identified by the `filename` property.
 
 - **Zarr** - Streams data to a [Zarr V2](https://zarr.readthedocs.io/en/stable/spec/v2.html) file with associated metadata.
-  
+
 - **ZarrBlosc1ZstdByteShuffle** - Streams compressed data (_zstd_ codec) to a [Zarr V2](https://zarr.readthedocs.io/en/stable/spec/v2.html) file with associated metadata.
-  
+
 - **ZarrBlosc1Lz4ByteShuffle** - Streams compressed data (_lz4_ codec) to a [Zarr V2](https://zarr.readthedocs.io/en/stable/spec/v2.html) file with associated metadata.
 
 ## Configure the Storage Device
@@ -62,7 +62,9 @@ config = runtime.get_configuration()
 config.video[0].storage.identifier = dm.select(acquire.DeviceKind.Storage, "tiff")
 
 # Set the data filename to out.tif in your current directory (provide the whole filetree to save to a different directory)
-config.video[0].storage.settings.filename = "out.tif" 
+config.video[0].storage.settings.filename = "out.tif"
 ```
 
 Before proceeding, complete the `Camera` setup and call `set_configuration` to save those new configuration settings.
+
+[Download this tutorial as a Python script](storage.py){ .md-button .md-button-center }

--- a/docs/tutorials/trig_json.md
+++ b/docs/tutorials/trig_json.md
@@ -55,3 +55,4 @@ You can load the trigger attributes in the JSON file to a `Trigger` object as sh
 trig = acquire.Trigger(**json.load(open('sample_trig.json')))
 ```
 
+[Download this tutorial as a Python script](trig_json.py){ .md-button .md-button-center }

--- a/docs/tutorials/trigger.md
+++ b/docs/tutorials/trigger.md
@@ -1,4 +1,5 @@
 # Finite Triggered Acquisition
+
 Acquire (`acquire-imaging` [on PyPI](https://pypi.org/project/acquire-imaging/)) is a Python package providing a multi-camera video streaming library focused on performant microscopy, with support for up to two simultaneous, independent, video streams.
 
 This tutorial shows an example of setting up triggered acquisition of a finite number of frames with one of Acquire's supported devices and saving the data to a Zarr file.
@@ -14,7 +15,7 @@ runtime = acquire.Runtime()
 
 ## Configure Camera
 
-All camera settings can be captured by an instance of the `Properties` class, which will be associated with a given camera acquisition. The settings can be stored in a dictionary (e.g: `Properties.dict()`). These settings can be saved to a JSON file to be subsequently loaded, (e.g. ` Properties(**json.load(open('acquire.json')))` ), using the [json library](https://docs.python.org/3/library/json.html#). Check out [this tutorial](props_json.md) for a more detailed example, but in brief, you would use something like:
+All camera settings can be captured by an instance of the `Properties` class, which will be associated with a given camera acquisition. The settings can be stored in a dictionary (e.g: `Properties.dict()`). These settings can be saved to a JSON file to be subsequently loaded, (e.g. `Properties(**json.load(open('acquire.json')))`), using the [json library](https://docs.python.org/3/library/json.html#). Check out [this tutorial](props_json.md) for a more detailed example, but in brief, you would use something like:
 
 ```python
 config = runtime.get_configuration()
@@ -27,7 +28,7 @@ with open("/path/to/acquire.json", "w") as f:
 The current configuration settings can be checked and assigned to an instance of the `Properties` class with:
 
 ```python
-config = runtime.get_configuration() 
+config = runtime.get_configuration()
 ```
 
 Since `Acquire` supports 2 video streams, each camera, or source, must be configured separately. In this example, we will only use 1 source for the acquisition, so we will only need to configure `config.video[0]`. To set the first video stream to [Hamamatsu Orca Fusion BT (C15440-20UP)](https://www.hamamatsu.com/eu/en/product/cameras/cmos-cameras/C15440-20UP.html), you can use the following with a regular expression to grab the Hamamatsu camera:
@@ -77,7 +78,7 @@ config.video[0].camera.settings.output_triggers.exposure = acquire.Trigger(
 `Storage` objects have identifiers which specify the file type (e.g. Zarr or tiff) and settings described by an instance of the `StorageProperties` class. We can set the file type to Zarr and set the file name to "out" with:
 
 ```python
-config.video[0].storage.identifier = runtime.device_manager().select(acquire.DeviceKind.Storage,'zarr') 
+config.video[0].storage.identifier = runtime.device_manager().select(acquire.DeviceKind.Storage,'zarr')
 config.video[0].storage.settings.filename="out.zarr"
 ```
 
@@ -96,6 +97,7 @@ You can optionally print out these settings using the [Rich](https://rich.readth
 from rich.pretty import pprint
 pprint(config.dict())
 ```
+
 Check out [this tutorial](https://acquire-project.github.io/acquire-docs/tutorials/props_json/) for a more detailed example of saving `Properties`.
 
 ## Acquire data
@@ -106,4 +108,6 @@ To begin acquisition:
 runtime.start()
 ```
 
-You can stop acquisition with `runtime.stop()` to stop after the max number of frames is collected or `runtime.abort()` to immediately stop acquisition. You must call one of these methods at the end of an acquisition, as `Runtime` deletes all of the objects created during acquisition to free up resources upon shutdown. Otherwise, an exception will be raised when trying to restart acquisition. 
+You can stop acquisition with `runtime.stop()` to stop after the max number of frames is collected or `runtime.abort()` to immediately stop acquisition. You must call one of these methods at the end of an acquisition, as `Runtime` deletes all of the objects created during acquisition to free up resources upon shutdown. Otherwise, an exception will be raised when trying to restart acquisition.
+
+[Download this tutorial as a Python script](trigger.py){ .md-button .md-button-center }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,7 @@ nav:
     - tutorials/drivers.md
     - tutorials/storage.md
     - tutorials/compressed.md
-  - For contributors: 
+  - For contributors:
     - for_contributors/index.md
     - for_contributors/docs_contribution_quickstart.md
 
@@ -57,6 +57,8 @@ markdown_extensions:
           - overrides/.icons
   - toc:
       permalink: true
+  - attr_list
+
 
 plugins:
   - include-markdown

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 mkdocs-material
 mkdocs-include-markdown-plugin
+jupytext
+pre-commit


### PR DESCRIPTION
Also sets up initial sync configuration between markdown and python files; adds download button to all tutorials; adds pre-commit hook to set up automatic check of sync'd md/py files.

I am happy to undo some of the whitespace changes if this is too much, but since jupytext can be very picky around new lines, I had to change some manually and figured having a check for this might help too, so a few extra files were touched.

Happy to take other approaches if preferred. Thanks!