### PR TITLE
Fix link to home in site name

### DIFF
--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -41,7 +41,7 @@
         <!-- Header title -->
         <div class="md-header__title" data-md-component="header-title">
             <div class="md-header__ellipsis">
-                <a href="index.html">{{ config.site_name }}</a>
+                <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}">{{ config.site_name }}</a>
             </div>
         </div>
 


### PR DESCRIPTION
Sorry, when I made the site clickable I added a link to the wrong pages. 