### PR TITLE
Remove logo on mobile menu

### DIFF
--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -18,6 +18,12 @@ html {
     display: none;
 }
 
+@media screen and (max-width: 76.2344em) {
+    .md-nav--primary .md-nav__title .md-logo {
+        display: none;
+    }
+}
+
 [dir="ltr"] .md-header__title {
     margin-left: 0.6rem;
 }


### PR DESCRIPTION
On mobile sizes, a mkdocs logo appears close to the site name:

![Screenshot_20240118_164429](https://github.com/acquire-project/acquire-docs/assets/3949932/8a51dc22-93e1-438b-9501-b2db9d2f0933)

This PR removes the logo.