### PR TITLE
Add script to convert tutorials to Python files

### DIFF
--- a/.github/workflows/convert.sh
+++ b/.github/workflows/convert.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+echo "Converting all .md tutorials to .py files..."
+cd ./docs/tutorials;
+for file in *.md; do
+    if [ "$file" != "index.md" ]; then
+        jupytext --to py $file
+    fi
+done
+cd -
+echo "Done."

--- a/.github/workflows/convert.sh
+++ b/.github/workflows/convert.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 echo "Converting all .md tutorials to .py files..."
-cd ./docs/tutorials;
+TUTS_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../../docs/tutorials"
+pushd ${TUTS_DIR}
 for file in *.md; do
     if [ "$file" != "index.md" ]; then
         jupytext --to py $file
     fi
 done
-cd -
+popd
 echo "Done."

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Generate downloadable scripts
         run: |
-          cd docs/tutorials; jupytext --to py *[!index].md; cd -
+          bash .github/workflows/convert.sh
 
       - name: Build website
         run: |


### PR DESCRIPTION
Fixes #20

For some reason, the glob syntax I was using was skipping a few files, so I decided to go with a more explicit script.